### PR TITLE
Add support for relative paths for exclusions

### DIFF
--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -376,7 +376,7 @@ class SourceGenerator {
             patterns.parallelMap { pattern in
                 guard !pattern.isEmpty else { return [] }
                 return Glob(pattern: "\(rootSourcePath)/\(pattern)")
-                    .map { Path($0) }
+                    .map { Path($0).absolute() }
                     .map {
                         guard $0.isDirectory else {
                             return [$0]


### PR DESCRIPTION
Includes already support relative paths, but excludes don't. This means if you did something like

```
targets:
  Foo:
    sources:
      path: ../Foo
      excludes:
        - ../Foo/Bar
```

then it wouldn't work. This fix corrects that issue.